### PR TITLE
Require `;` after `println()`

### DIFF
--- a/examples/factorial.toys
+++ b/examples/factorial.toys
@@ -8,5 +8,5 @@ define factorial(n) {
 
 define main() {
   res = factorial(5);
-  println(res)
+  println(res);
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -80,10 +80,11 @@ fn line(input: &str) -> IResult<&str, ast::Expression> {
     )(input)
 }
 
-/// println <- "println" "(" expression ")";
+/// println <- "println" "(" expression ")" ";";
 fn println(input: &str) -> IResult<&str, ast::Expression> {
     let (input, _) = terminated(tag("println"), multispace0)(input)?;
-    let (input, ast_expression) = helper_combinators::parentheses(expression)(input)?;
+    let (input, ast_expression) =
+        terminated(helper_combinators::parentheses(expression), tag(";"))(input)?;
 
     Ok((input, ast::ast_println(ast_expression)))
 }
@@ -551,7 +552,7 @@ mod tests {
     fn println_test() {
         let mut interpreter = Interpreter::new();
 
-        let input = "println(42)";
+        let input = "println(42);";
         let (_, expression) = println(input).unwrap();
         let value = interpreter.interpret(&expression).unwrap();
 


### PR DESCRIPTION
It's quite confiusing that `println()` is NOT terminated with semicolon.
In this PR we make it mandatory to put `;` right after `println()`.